### PR TITLE
Feature/nodes crud endpoints

### DIFF
--- a/apps/backend/src/nodes/dto/create-node.ts
+++ b/apps/backend/src/nodes/dto/create-node.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { IsNotEmpty, IsString } from "class-validator";
 
-enum NoteType {
+export enum NoteType {
   FOLDER = "folder",
   NOTE = "note",
 }

--- a/apps/backend/src/nodes/dto/create-node.ts
+++ b/apps/backend/src/nodes/dto/create-node.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { IsNotEmpty, IsString } from "class-validator";
 
-export enum NoteType {
+ enum NoteType {
   FOLDER = "folder",
   NOTE = "note",
 }

--- a/apps/backend/src/nodes/dto/update-node.ts
+++ b/apps/backend/src/nodes/dto/update-node.ts
@@ -1,9 +1,22 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsString } from "class-validator";
+import { NoteType } from "./create-node";
+import { Optional } from "@nestjs/common";
 
 export class UpdateNodeDto {
+
   @IsString()
-  @IsNotEmpty()
+  @Optional()
   @ApiProperty()
   title: string;
+
+  @Optional()
+  @IsString()
+  @ApiProperty()
+  type: NoteType;
+
+  @Optional()
+  @IsString()
+  @ApiProperty()
+  parentId: string | null;
 }

--- a/apps/backend/src/nodes/dto/update-node.ts
+++ b/apps/backend/src/nodes/dto/update-node.ts
@@ -1,22 +1,10 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsString } from "class-validator";
-import { NoteType } from "./create-node";
-import { Optional } from "@nestjs/common";
+import { IsNotEmpty, IsString } from "class-validator";
 
 export class UpdateNodeDto {
 
   @IsString()
-  @Optional()
+  @IsNotEmpty()
   @ApiProperty()
   title: string;
-
-  @Optional()
-  @IsString()
-  @ApiProperty()
-  type: NoteType;
-
-  @Optional()
-  @IsString()
-  @ApiProperty()
-  parentId: string | null;
 }

--- a/apps/backend/src/nodes/nodes.controller.ts
+++ b/apps/backend/src/nodes/nodes.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post,
   Put,
   Request,
@@ -32,9 +33,10 @@ export class NodesController {
   ) {
     return await this.nodesService.updatenode(dto.title, id, req.user._id);
   }
+  
   @Delete(":id")
   async softDeleteNode(@Param("id") id: string, @Request() req) {
-    return await this.softDeleteNode(id, req.user._id);
+    return await this.nodesService.sortDelete(id, req.user._id);
   }
 
   @Get("")
@@ -42,6 +44,8 @@ export class NodesController {
     return await this.nodesService.getNoteTree(req.user._id);
   }
 
-  @Get(":id")
-  async isFavorite(@Request() req, @Param("id") id: string) {}
+  @Patch(":id/favorite")
+  async toggleFavorite(@Param("id") id: string, @Request() req) {
+    return await this.nodesService.handlefavorite(id, req.user._id);
+  }
 }

--- a/apps/backend/src/nodes/nodes.service.ts
+++ b/apps/backend/src/nodes/nodes.service.ts
@@ -12,102 +12,153 @@ export class NodesService {
     @InjectModel(Node.name) private nodeModel: Model<Node>,
     @InjectModel(Note.name) private noteModel: Model<Note>,
     private readonly buildTree: BuildTree,
-  ) {}
+  ) { }
 
   async create(dto: CreateNodeDto, userId: string) {
-    const isTitleExist = await this.nodeModel.findOne({
-      parentId: dto.parentId,
-      title: dto.title,
-      ownerId: userId,
-    });
+    try {
 
-    if (isTitleExist) {
-      throw new BadRequestException("the title is already used");
-    }
-
-    if (dto.parentId) {
-      const parent = await this.nodeModel.findOne({
-        type: "folder",
-        _id: dto.parentId,
+      const isTitleExist = await this.nodeModel.findOne({
+        parentId: dto.parentId,
+        title: dto.title,
         ownerId: userId,
       });
 
-      if (!parent) {
-        throw new BadRequestException("this folder does not exist");
+      if (isTitleExist) {
+        throw new BadRequestException("the title is already used");
       }
-    }
 
-    const newNode = new this.nodeModel({
-      type: dto.type,
-      title: dto.title,
-      parentId: dto.parentId,
-      ownerId: userId,
-    });
-    await newNode.save();
+      if (dto.parentId) {
+        const parent = await this.nodeModel.findOne({
+          type: "folder",
+          _id: dto.parentId,
+          ownerId: userId,
+        });
 
-    if (dto.type === "note") {
-      const newNote = new this.noteModel({
-        nodeId: newNode._id,
+        if (!parent) {
+          throw new BadRequestException("this folder does not exist");
+        }
+      }
+
+      const newNode = new this.nodeModel({
+        type: dto.type,
+        title: dto.title,
+        parentId: dto.parentId,
+        ownerId: userId,
       });
+      await newNode.save();
 
-      await newNote.save();
+      if (dto.type === "note") {
+        const newNote = new this.noteModel({
+          nodeId: newNode._id,
+        });
+
+        await newNote.save();
+      }
+      return {
+        message: "item created successfully",
+        node: newNode,
+      };
+    } catch (error) {
+      return { errorMessage: error }
     }
-    return {
-      message: "item created successfully",
-      node: newNode,
-    };
   }
+
   async sortDelete(id: string, userId: string) {
-    const node = await this.nodeModel.findOneAndUpdate(
-      {
-        _id: id,
-        ownerId: userId,
-      },
-      {
-        isTrash: true,
-      },
-      {
-        new: true,
-      },
-    );
+    try {
+      const node = await this.nodeModel.findOneAndUpdate(
+        {
+          _id: id,
+          ownerId: userId,
+          isTrash: false,
+        },
+        {
+          isTrash: true,
+        },
+        {
+          new: true,
+        },
+      );
 
-    if (!node) {
-      throw new Error("Node not found or unauthorized");
+      if (!node) {
+        return { errorMessage: "Node not found or unauthorized" };
+      }
+      return node;
+    } catch (error) {
+      return { errorMessage: error }
     }
-
-    return node;
   }
-  async delete(id: string, userId: string) {}
-  async handlefavorite(id: string, userId: string) {}
+
+  async delete(id: string, userId: string) {
+    try {
+      const result = await this.nodeModel.deleteOne({ _id: id, ownerId: userId })
+
+      if (result.deletedCount === 0) {
+        throw new BadRequestException("Node not found or unauthorized");
+      }
+      return { message: "Node permanently deleted" };
+    } catch (error) {
+      return { errorMessage: error }
+    }
+  }
+
+  async handlefavorite(id: string, userId: string) {
+    try {
+      const node = await this.nodeModel.findOne({ _id: id, ownerId: userId });
+
+      if (!node) {
+        throw new BadRequestException("Node not found or unauthorized")
+      }
+
+      node.isFavorite = !node.isFavorite;
+      await node.save();
+
+      return {
+        message: node.isFavorite ? "Added to favorites" : "Removed from favorites",
+        node,
+      };
+    } catch (error) {
+      return { errorMessage: error }
+    }
+  }
+
   async updatenode(title: string, id: string, userId: string) {
-    const node = await this.nodeModel.findOneAndUpdate(
-      {
-        _id: id,
-        ownerId: userId,
-      },
-      { title },
-      { new: true },
-    );
+    try {
+      const node = await this.nodeModel.findOneAndUpdate(
+        {
+          _id: id,
+          ownerId: userId,
+        },
+        { title },
+        { new: true },
+      );
 
-    if (!node) {
-      throw new Error("Node not found or unauthorized");
+      if (!node) {
+        return { errorMessage: "Node not found or unauthorized" };
+      }
+
+      return node;
+    } catch (error) {
+      return { errorMessage: error }
     }
-
-    return node;
   }
+
   async getNoteTree(userId: string) {
-    const nodes = await this.nodeModel.find({
-      ownerId: userId,
-      isTrash: false,
-    });
-    const sortedNodes = nodes.sort((a, b) => {
-      if (a.type === b.type) return 0;
-      if (a.type === "folder") return -1;
-      return 1;
-    });
-    const map = this.buildTree.buildNormalized(sortedNodes);
-    return {
-      map,
-    };
+    try {
+      const nodes = await this.nodeModel.find({
+        ownerId: userId,
+        isTrash: false,
+      });
+      const sortedNodes = nodes.sort((a, b) => {
+        if (a.type === b.type) return 0;
+        if (a.type === "folder") return -1;
+        return 1;
+      });
+      const map = this.buildTree.buildNormalized(sortedNodes);
+      return {
+        map,
+      };
+    } catch (error) {
+      return { errorMessage: error }
+    }
   }
 }


### PR DESCRIPTION
## Description
Completed the missing CRUD operations, soft delete, and favorite toggle functionalities inside the `Nodes` module as requested. 

### Changes Made:
- **Controller Fix:** Resolved a recursive stack overflow bug in the `@Delete(':id')` endpoint by correctly routing it to call the service's `sortDelete` method instead of self-invoking.
- **Toggle Favorite Functionality:** Implemented a new `@Patch(':id/favorite')` endpoint in the controller and added corresponding logic in `NodesService.handlefavorite()` to dynamically toggle the favorite status of a node document in Mongoose.

## Verification & Testing
- Verified compilation and server start via `npm run start:dev`.
- Created and tested a complete Postman collection verifying that all updated endpoints work correctly with JWT authentication middleware.

Closes #11