### PR TITLE
fix(ci): fix pnpm setup order, service health checks, and turbo config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,15 +16,30 @@ jobs:
         image: mongo:7
         ports:
           - 27017:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.runCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
       redis:
         image: redis:7
         ports:
           - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -32,16 +47,8 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Wait for MongoDB and Redis
-        run: sleep 10
 
       - name: Run backend tests
         env:
@@ -49,7 +56,9 @@ jobs:
           MONGO_URL: mongodb://localhost:27017/test_db
           REDIS_URL: redis://localhost:6379
           JWT_SECRET: test_secret
-        run: pnpm --filter backend test
+        run: pnpm --filter backend test --forceExit
 
       - name: Run frontend tests
-        run: pnpm --filter frontend test
+        env:
+          NODE_ENV: test
+        run: pnpm --filter frontend test --passWithNoTests

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
-  "ui": "tui",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -12,6 +11,10 @@
     },
     "check-types": {
       "dependsOn": ["^check-types"]
+    },
+    "test": {
+      "cache": false,
+      "inputs": ["src/**/*.ts", "test/**/*.ts", "**/*.spec.ts", "**/*.e2e-spec.ts"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
- Move pnpm/action-setup before setup-node so node cache can detect pnpm
- Replace fragile sleep 10 with proper Docker health checks for MongoDB and Redis
- Add --forceExit to backend tests to prevent hanging open connections
- Add --passWithNoTests to frontend tests to avoid failure with no test files
- Add shamefully-hoist=true and strict-peer-dependencies=false to .npmrc for NestJS monorepo compatibility
- Remove ui:tui from turbo.json (crashes in non-interactive CI terminals)
- Add test task to turbo.json with cache disabled (tests use live services)